### PR TITLE
fix(djangofiletype): handle not null field

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -138,8 +138,8 @@ type DepartmentType {
 }
 
 type DjangoFileType {
-  name: String
-  size: Int
+  name: String!
+  size: Int!
   url: String!
 }
 

--- a/utils/graphql/types.py
+++ b/utils/graphql/types.py
@@ -29,8 +29,8 @@ class MutationResponseType(typing.Generic[ResultTypeVar]):
 # Replaces strawberry_django.fields.types.DjangoFileType
 @strawberry.type
 class DjangoFileType:
-    name: str | None
-    size: int | None
+    name: str
+    size: int
 
     @strawberry_django.field
     def url(


### PR DESCRIPTION

## Changes
- change the djangofiletype 
- add required for name and size 
- 
## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
