### PR TITLE
Feat:Add commit lint on ci

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,11 @@
+name: Lint commits
+
+on: [pull_request]
+
+jobs:
+  lint:
+    name: Commit Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - uses: toggle-corp/commit-lint@main


### PR DESCRIPTION

* Add commit lint on ci 

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
