### PR TITLE
fix: increase file size limit for resource files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,13 @@ log_cli = true
 
 [tool.ruff]
 line-length = 125
+# FIXME: Remove uv.lock later
 extend-exclude = [
     ".git",
     ".pytest_cache",
     ".mypy_cache",
     ".ruff_cache",
+    "uv.lock",
     ".venv",
     "venv",
     "**/migrations/*",

--- a/utils/common.py
+++ b/utils/common.py
@@ -36,7 +36,7 @@ def unique_slugify(instance: T, slug: str) -> str:
 
 
 MAX_IMAGE_FILE_SIZE = 4
-MAX_FILE_SIZE = 7
+MAX_FILE_SIZE = 30
 MAX_RADIO_PROGRAM_FILE_SIZE = 40
 
 


### PR DESCRIPTION
## Changes

* increase file size limit for resource files

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
